### PR TITLE
Added Boost Brake Macro for you to toy with.

### DIFF
--- a/Warthog Script/AD_EDMacros_v4.X.X.tmh
+++ b/Warthog Script/AD_EDMacros_v4.X.X.tmh
@@ -2,7 +2,7 @@
 // START-UP: MACRO VARIABLE INITALISATION //
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------//
 
-	int mRequestDock, mShowGameStats, mFastModeSwitch, mChatPanelGrab, mSignalLights, mSignalLightsLong, mReportCrimesToggle;
+	int mRequestDock, mShowGameStats, mFastModeSwitch, mChatPanelGrab, mSignalLights, mSignalLightsLong, mReportCrimesToggle, mBoostBrake;
 	int mNAVBeaconWing, mNAVBeaconOff, mNAVBeaconToggle, mJumpMidSubSys, mJumpPrevSubSys, mJumpNextSubSys;
 	int mThrottleFwdOnly, mThrottleFullScale, mThrottlePrecision, mThrottleTrimmed, mThrottleFullNonLinear, mThrottleFwdNonLinear, mThrottleFullScaleCustom; 	// Configured/Used in AD_EDHardware.tmh
 
@@ -150,7 +150,12 @@
 			PULSE+UIBack,				D(50),
 			PULSE+CommsPanel,			D(250),													// Open Full Comms Panel (+GUI Delay - Default: 250ms) (Delay ensures panel is Open and Text Box Active before entering characters)
 			PULSE+QuickCommsPanel,		D(150),													// Select/Enter Text Chat Box
-			LOCK); }																			// Unlock Ready for Text String Input
+			LOCK); 																			// Unlock Ready for Text String Input
+
+		mBoostBrake = CHAIN(																	// P34vP Boost Brake Test
+			PULSE+EngineBoost,			D(360),
+			PULSE+LandingGear,			D(3600),
+			PULSE+LandingGear);	}																// End P34vP BB Test
 
 
 


### PR DESCRIPTION
You can see the changes I made to my personal version, and go from there.  
I moved FSS to S4 + MSL in binds in elite, boost is on MSR since I use a DSE Slew Adapter and wanted so move boost and font need vert thrust digital anywhere.  I'm extremely happy with how mine is, but I know yours is more Universal.  Also, toying with the timings, but where its at is pretty darn good, might shorten it a hair.  
This is very useful for "Half Turns" in FAOff.