### PR TITLE
Made application of throttle presets to left throttle axis optional

### DIFF
--- a/Warthog Script/AD_EDHardware_v4.2.1.tmh
+++ b/Warthog Script/AD_EDHardware_v4.2.1.tmh
@@ -66,46 +66,86 @@
 		}
 	}
 	
+	// Initialising Throttle Forward Only Preset (SRV etc)
+	int _doThrottleFwdOnly() {
+		_trimThrottleAxes(-1024);
+		if(CruiseOnThrottle) {
+			_setThrottleSCurve(0, -95, 0, 0);													// Trims Axis 5% when Supercruise On Throttle Active
+		} else {
+			_setThrottleSCurve(0, -100, 0, 0);
+		}
+		if(VerboseOutput) printf("Throttle Profile: FORWARD ONLY [0 -> 100]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Forward Only Non-Linear Preset (SRV etc)
+	// <Unmapped by Default> (See User Preferences to Set)
+	int _doThrottleFwdNonLinear() {
+		_trimThrottleAxes(-1024);
+		_setThrottleCustomCurve(AxisCurveMod);													// DX-SLIDER Non-Linear progression Curve
+		if(VerboseOutput) printf("Throttle Profile: NON-LINEAR FORWARD ONLY [0 ~> 100]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Full Range & Make Throttle Linear (Default)
+	int _doThrottleFullScale() {
+		_trimThrottleAxes(0);																	// Initialising Throttle Full Scale Preset
+		if(CruiseOnThrottle) {
+			_setThrottleSCurve(0, TFULL_DEADZONE, 5, 0);										// Trims Axis 5% when Supercruise On Throttle Active
+		} else {
+			_setThrottleSCurve(0, TFULL_DEADZONE, 0, 0);										// ..(Alternative= "_setThrottleJCurve(50, 50);")
+		}
+		if(VerboseOutput) printf("Throttle Profile: FULL SCALE [-100 -> 100]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Full Range & Make Throttle Non-Linear
+	// <Unmapped by Default> (See User Preferences to Set)
+	int _doThrottleFullNonLinear() {
+		_trimThrottleAxes(0);								
+		_setThrottleCustomCurve(AxisCurveMod);													// DX-SLIDER Non-Linear progression Curve
+		if(VerboseOutput) printf("Throttle Profile: NON-LINEAR [-100 ~> 100]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Full Range & Max Shorter @ 80% Preset (ALTERNATIVE)
+	// Slightly Shorter Forward travel distance for my RSeat RS1 Cockpit setup. :)
+	// <Unmapped by Default> (See User Preferences to Set)
+	int _doThrottleFullScaleCustom() {
+		_trimThrottleAxes(0);
+		_setThrottleJCurve(80, 100);
+		if(VerboseOutput) printf("Throttle Profile: FULL SCALE CUSTOM [-100 -> 80]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Trimmed 25% @ Beginning/End Preset (ALTERNATIVE)
+	// <Unmapped by Default> (See User Preferences to Set)
+	int _doThrottleTrimmed() {
+		_trimThrottleAxes(0);
+		_setThrottleSCurve(-25, 0, -25, 0);
+		if(VerboseOutput) printf("Throttle Profile: TRIMMED [-75 -> 75]\x0a");
+		SetThrottle();
+	}
+
+	// Initialising Throttle Precision Preset (Docking etc)
+	// Allows Throttle Movement ONLY to the middle of blue zone
+	int _doThrottlePrecision() {
+		_trimThrottleAxes(0);
+		_setThrottleSCurve(0, 2, 0, 2, -2);
+		if(VerboseOutput) printf("Throttle Profile: PRECISION [-50 -> 50]\x0a");
+		SetThrottle();
+	}
 
 																								// FLAP position sets Throttle Curve Profile
 	int initSetThrottleCurves() {																// Three different presets are selectable On-The-Fly
-		mThrottleFwdOnly		 = EXEC(  														// Initialising Throttle Forward Only Preset (SRV etc)
-								"_trimThrottleAxes(-1024);"
-								"if(CruiseOnThrottle == 0) { _setThrottleSCurve(0, -100, 0, 0); }"
-								"if(CruiseOnThrottle == 1) { _setThrottleSCurve(0, -95, 0, 0); }"				// Trims Axis 5% when Supercruise On Throttle Active
-								"if(VerboseOutput) printf(\"Throttle Profile: FORWARD ONLY [0 -> 100]\\x0a\");"
-								"SetThrottle();");
-		mThrottleFwdNonLinear	 = EXEC(														// Initialising Throttle Forward Only Non-Linear Preset (SRV etc)
-								"_trimThrottleAxes(-1024);"										// <Unmapped by Default> (See User Preferences to Set)
-								"_setThrottleCustomCurve(AxisCurveMod);" 						// DX-SLIDER Non-Linear progression Curve
-								"if(VerboseOutput) printf(\"Throttle Profile: NON-LINEAR FORWARD ONLY [0 ~> 100]\\x0a\");"
-								"SetThrottle();");
-		mThrottleFullScale		 = EXEC(  														// Initialising Throttle Full Range & Make Throttle Linear (Default)
-								"_trimThrottleAxes(0);"											// Initialising Throttle Full Scale Preset
-								"if(CruiseOnThrottle == 0) { _setThrottleSCurve(0, TFULL_DEADZONE, 0, 0); }"	// ..(Alternative= "SetJCurve(&Throttle, THR_RIGHT, 50, 50);")
-								"if(CruiseOnThrottle == 1) { _setThrottleSCurve(0, TFULL_DEADZONE, 5, 0); }"	// Trims Axis 5% when Supercruise On Throttle Active
-								"if(VerboseOutput) printf(\"Throttle Profile: FULL SCALE [-100 -> 100]\\x0a\");"
-								"SetThrottle();");
-		mThrottleFullNonLinear	 = EXEC(														// Initialising Throttle Full Range & Make Throttle Non-Linear
-								"_trimThrottleAxes(0);"											// <Unmapped by Default> (See User Preferences to Set)								"if(SyncLEFTTHRAxis) { TrimDXAxis(DX_ZROT_AXIS, SET(0)); }"
-								"_setThrottleCustomCurve(AxisCurveMod);"							// DX-SLIDER Non-Linear progression Curve
-								"if(VerboseOutput) printf(\"Throttle Profile: NON-LINEAR [-100 ~> 100]\\x0a\");"
-								"SetThrottle();");
-		mThrottleFullScaleCustom = EXEC(  														// Initialising Throttle Full Range & Max Shorter @ 80% Preset (ALTERNATIVE)
-								"_trimThrottleAxes(0);"											// Slightly Shorter Forward travel distance for my RSeat RS1 Cockpit setup. :)
-								"_setThrottleJCurve(80, 100);"									// <Unmapped by Default> (See User Preferences to Set)
-								"if(VerboseOutput) printf(\"Throttle Profile: FULL SCALE CUSTOM [-100 -> 80]\\x0a\");"
-								"SetThrottle();");
-		mThrottleTrimmed		 = EXEC(  														// Initialising Throttle Trimmed 25% @ Beginning/End Preset (ALTERNATIVE)
-								"_trimThrottleAxes(0);"											// <Unmapped by Default> (See User Preferences to Set)
-								"_setThrottleSCurve(-25, 0, -25, 0);"
-								"if(VerboseOutput) printf(\"Throttle Profile: TRIMMED [-75 -> 75]\\x0a\");"
-								"SetThrottle();");
-		mThrottlePrecision		 = EXEC( 														// Initialising Throttle Precision Preset (Docking etc)
-								"_trimThrottleAxes(0);"											// Allows Throttle Movement ONLY to the middle of blue zone
-								"_setThrottleSCurve(0, 2, 0, 2, -2);"
-								"if(VerboseOutput) printf(\"Throttle Profile: PRECISION [-50 -> 50]\\x0a\");"
-								"SetThrottle();"); }
+		mThrottleFwdOnly		 = EXEC("_doThrottleFwdOnly();");								// Initialising Throttle Forward Only Preset (SRV etc)
+		mThrottleFwdNonLinear	 = EXEC("_doThrottleFwdNonLinear();");							// Initialising Throttle Forward Only Non-Linear Preset (SRV etc)
+		mThrottleFullScale		 = EXEC("_doThrottleFullScale();");								// Initialising Throttle Full Range & Make Throttle Linear (Default)
+		mThrottleFullNonLinear	 = EXEC("_doThrottleFullNonLinear();");							// Initialising Throttle Full Range & Make Throttle Non-Linear
+		mThrottleFullScaleCustom = EXEC("_doThrottleFullScaleCustom();");						// Initialising Throttle Full Range & Max Shorter @ 80% Preset (ALTERNATIVE)
+		mThrottleTrimmed		 = EXEC("_doThrottleTrimmed();");								// Initialising Throttle Trimmed 25% @ Beginning/End Preset (ALTERNATIVE)
+		mThrottlePrecision		 = EXEC("_doThrottlePrecision();");								// Initialising Throttle Precision Preset (Docking etc)
+	}
 
 
 

--- a/Warthog Script/AD_EDHardware_v4.2.1.tmh
+++ b/Warthog Script/AD_EDHardware_v4.2.1.tmh
@@ -35,43 +35,75 @@
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------//
 // HARDWARE: THROTTLE AXIS MAPPINGS //															// Define All Axis Curves/Trim/Deadzones for Device
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+	// Throttle utility functions:
+
+	int _trimThrottleAxes(int value) {
+		TrimDXAxis(DX_Z_AXIS, SET(value));	 													// *TrimDXAxis(axis, +/-1024) trim is additive, SET forces trim value, CURRENT reads axis.pos
+		if(SyncLEFTTHRAxis) {
+			TrimDXAxis(DX_ZROT_AXIS, SET(value));
+		}
+	}
+	
+	int _setThrottleSCurve(int lower=0, int center=0, int upper=0, int curve=0, float zoom=0) {
+		SetSCurve(&Throttle, THR_RIGHT, lower, center, upper, curve, zoom);						// *SetSCurve(&Device, axis, left_deadzone%, center_deadzone%, right_deadzone%, curve(-20...20), scale)
+		if(SyncLEFTTHRAxis) {
+			SetSCurve(&Throttle, THR_LEFT, lower, center, upper, curve, zoom);
+		}
+	}
+
+	int _setThrottleJCurve(float in, float out) {
+		SetJCurve(&Throttle, THR_RIGHT, in, out);												// *SetJCurve(&device, axis, physical axis value%, DirectX output value%)
+		if(SyncLEFTTHRAxis) {
+			SetJCurve(&Throttle, THR_LEFT, in, out);
+		}
+	}
+
+	int _setThrottleCustomCurve(int list) {
+		SetCustomCurve(&Throttle, THR_RIGHT, list);
+		if(SyncLEFTTHRAxis) {
+			SetCustomCurve(&Throttle, THR_LEFT, list);
+		}
+	}
+	
+
 																								// FLAP position sets Throttle Curve Profile
 	int initSetThrottleCurves() {																// Three different presets are selectable On-The-Fly
 		mThrottleFwdOnly		 = EXEC(  														// Initialising Throttle Forward Only Preset (SRV etc)
-								"TrimDXAxis(DX_Z_AXIS, SET(-1024));" "TrimDXAxis(DX_ZROT_AXIS, SET(-1024));"							// *TrimDXAxis(axis, +/-1024) trim is additive, SET forces trim value, CURRENT reads axis.pos
-								"if(CruiseOnThrottle == 0) { SetSCurve(&Throttle, THR_RIGHT, 0, -100, 0, 0); SetSCurve(&Throttle, THR_LEFT, 0, -100, 0, 0); }" 			// *SetSCurve(&Device, axis, left_deadzone%, center_deadzone%, right_deadzone%, curve(-20...20), scale)
-								"if(CruiseOnThrottle == 1) { SetSCurve(&Throttle, THR_RIGHT, 0, -95, 0, 0);  SetSCurve(&Throttle, THR_LEFT, 0, -95, 0, 0); }"				// Trims Axis 5% when Supercruise On Throttle Active
+								"_trimThrottleAxes(-1024);"
+								"if(CruiseOnThrottle == 0) { _setThrottleSCurve(0, -100, 0, 0); }"
+								"if(CruiseOnThrottle == 1) { _setThrottleSCurve(0, -95, 0, 0); }"				// Trims Axis 5% when Supercruise On Throttle Active
 								"if(VerboseOutput) printf(\"Throttle Profile: FORWARD ONLY [0 -> 100]\\x0a\");"
 								"SetThrottle();");
 		mThrottleFwdNonLinear	 = EXEC(														// Initialising Throttle Forward Only Non-Linear Preset (SRV etc)
-								"TrimDXAxis(DX_Z_AXIS, SET(-1024));" "TrimDXAxis(DX_ZROT_AXIS, SET(-1024));"	// <Unmapped by Default> (See User Preferences to Set)
-								"SetCustomCurve(&Throttle, THR_RIGHT, AxisCurveMod);" "SetCustomCurve(&Throttle, THR_LEFT, AxisCurveMod);"	// DX-SLIDER Non-Linear progression Curve
+								"_trimThrottleAxes(-1024);"										// <Unmapped by Default> (See User Preferences to Set)
+								"_setThrottleCustomCurve(AxisCurveMod);" 						// DX-SLIDER Non-Linear progression Curve
 								"if(VerboseOutput) printf(\"Throttle Profile: NON-LINEAR FORWARD ONLY [0 ~> 100]\\x0a\");"
 								"SetThrottle();");
 		mThrottleFullScale		 = EXEC(  														// Initialising Throttle Full Range & Make Throttle Linear (Default)
-								"TrimDXAxis(DX_Z_AXIS, SET(0));" "TrimDXAxis(DX_ZROT_AXIS, SET(0));"			// Initialising Throttle Full Scale Preset
-								"if(CruiseOnThrottle == 0) { SetSCurve(&Throttle, THR_RIGHT, 0, TFULL_DEADZONE, 0, 0); SetSCurve(&Throttle, THR_LEFT, 0, TFULL_DEADZONE, 0, 0); }"	// ..(Alternative= "SetJCurve(&Throttle, THR_RIGHT, 50, 50);")
-								"if(CruiseOnThrottle == 1) { SetSCurve(&Throttle, THR_RIGHT, 0, TFULL_DEADZONE, 5, 0); SetSCurve(&Throttle, THR_LEFT, 0, TFULL_DEADZONE, 5, 0); }"	// Trims Axis 5% when Supercruise On Throttle Active
+								"_trimThrottleAxes(0);"											// Initialising Throttle Full Scale Preset
+								"if(CruiseOnThrottle == 0) { _setThrottleSCurve(0, TFULL_DEADZONE, 0, 0); }"	// ..(Alternative= "SetJCurve(&Throttle, THR_RIGHT, 50, 50);")
+								"if(CruiseOnThrottle == 1) { _setThrottleSCurve(0, TFULL_DEADZONE, 5, 0); }"	// Trims Axis 5% when Supercruise On Throttle Active
 								"if(VerboseOutput) printf(\"Throttle Profile: FULL SCALE [-100 -> 100]\\x0a\");"
-								"SetThrottle();");												// *SetJCurve(&device, axis, physical axis value%, DirectX output value%)
+								"SetThrottle();");
 		mThrottleFullNonLinear	 = EXEC(														// Initialising Throttle Full Range & Make Throttle Non-Linear
-								"TrimDXAxis(DX_Z_AXIS, SET(0));" "TrimDXAxis(DX_ZROT_AXIS, SET(0));"			// <Unmapped by Default> (See User Preferences to Set)
-								"SetCustomCurve(&Throttle, THR_RIGHT, AxisCurveMod);" "SetCustomCurve(&Throttle, THR_LEFT, AxisCurveMod);"	// DX-SLIDER Non-Linear progression Curve
+								"_trimThrottleAxes(0);"											// <Unmapped by Default> (See User Preferences to Set)								"if(SyncLEFTTHRAxis) { TrimDXAxis(DX_ZROT_AXIS, SET(0)); }"
+								"_setThrottleCustomCurve(AxisCurveMod);"							// DX-SLIDER Non-Linear progression Curve
 								"if(VerboseOutput) printf(\"Throttle Profile: NON-LINEAR [-100 ~> 100]\\x0a\");"
 								"SetThrottle();");
 		mThrottleFullScaleCustom = EXEC(  														// Initialising Throttle Full Range & Max Shorter @ 80% Preset (ALTERNATIVE)
-								"TrimDXAxis(DX_Z_AXIS, SET(0));" "TrimDXAxis(DX_ZROT_AXIS, SET(0));"			// Slightly Shorter Forward travel distance for my RSeat RS1 Cockpit setup. :)
-								"SetJCurve(&Throttle, THR_RIGHT, 80, 100);" "SetJCurve(&Throttle, THR_LEFT, 80, 100);"	// <Unmapped by Default> (See User Preferences to Set)
+								"_trimThrottleAxes(0);"											// Slightly Shorter Forward travel distance for my RSeat RS1 Cockpit setup. :)
+								"_setThrottleJCurve(80, 100);"									// <Unmapped by Default> (See User Preferences to Set)
 								"if(VerboseOutput) printf(\"Throttle Profile: FULL SCALE CUSTOM [-100 -> 80]\\x0a\");"
 								"SetThrottle();");
 		mThrottleTrimmed		 = EXEC(  														// Initialising Throttle Trimmed 25% @ Beginning/End Preset (ALTERNATIVE)
-								"TrimDXAxis(DX_Z_AXIS, SET(0));" "TrimDXAxis(DX_ZROT_AXIS, SET(0));"			// <Unmapped by Default> (See User Preferences to Set)
-								"SetSCurve(&Throttle, THR_RIGHT, -25, 0, -25, 0);" "SetSCurve(&Throttle, THR_LEFT, -25, 0, -25, 0);"
+								"_trimThrottleAxes(0);"											// <Unmapped by Default> (See User Preferences to Set)
+								"_setThrottleSCurve(-25, 0, -25, 0);"
 								"if(VerboseOutput) printf(\"Throttle Profile: TRIMMED [-75 -> 75]\\x0a\");"
 								"SetThrottle();");
 		mThrottlePrecision		 = EXEC( 														// Initialising Throttle Precision Preset (Docking etc)
-								"TrimDXAxis(DX_Z_AXIS, SET(0));" "TrimDXAxis(DX_ZROT_AXIS, SET(0));"			// Allows Throttle Movement ONLY to the middle of blue zone
-								"SetSCurve(&Throttle, THR_RIGHT, 0, 2, 0, 2, -2);" "SetSCurve(&Throttle, THR_LEFT, 0, 2, 0, 2, -2);"
+								"_trimThrottleAxes(0);"											// Allows Throttle Movement ONLY to the middle of blue zone
+								"_setThrottleSCurve(0, 2, 0, 2, -2);"
 								"if(VerboseOutput) printf(\"Throttle Profile: PRECISION [-50 -> 50]\\x0a\");"
 								"SetThrottle();"); }
 
@@ -103,8 +135,11 @@
 
 
 	int SetThrottle() {																			// Prevents Throttle jumping around on mode changes
-		DXAxis(DX_Z_AXIS,   -AxisVal(Throttle[THR_RIGHT], &axdata));
-		if(!DisableLEFTTHRAxis) DXAxis(DX_ZROT_AXIS, -AxisVal(Throttle[THR_LEFT], &axdata)); }
+		DXAxis(DX_Z_AXIS, -AxisVal(Throttle[THR_RIGHT], &axdata));
+		if(!DisableLEFTTHRAxis & SyncLEFTTHRAxis) {
+			DXAxis(DX_ZROT_AXIS, -AxisVal(Throttle[THR_LEFT], &axdata));
+		}
+	}
 
 
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------//
@@ -125,3 +160,4 @@
 
 
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------//
+

--- a/Warthog Script/AD_EDUserPrefs_v4.2.1.tmh
+++ b/Warthog Script/AD_EDUserPrefs_v4.2.1.tmh
@@ -52,7 +52,9 @@
 	define ThrottlePresetDWNALT mNextTurretModeX2		// If ThrottleOverride = 1, this will determine what custom 'Pulse' mapping is applied to the DOWN direction of the Throttle Toggle. (NOTE: To avoid potential 3-way mapping conflicts, the MIDDLE position on the Toggle will remain NULL/Empty.)
 
 	define DisableLEFTTHRAxis	0						// Whenever a Throttle Preset is applied, it is applied to both the Left & Right Throttle Axes. ED only requires one to be mapped. This option allows you to disable the Left Throttle Axis if you require the mappings for another device axis in the virtual device.
-														// 	 Options:	Enable Left Axis = 0 (default)				Disable Left Axis = 1	
+														// 	 Options:	Enable Left Axis = 0 (default)				Disable Left Axis = 1
+	define SyncLEFTTHRAxis 		1						// Whenever a Throttle Preset is applied, this ensures the preset is applied to both the Left & Right Throttle Axes. Disabling this will cause the Left Throttle Axis to maintain its full range regardless of the preset that is used.
+														//   Options:   Enable Left Axis Sync = 1 (default)         Disable Left Axis Sync = 0	
 		// JOYSTICK AXIS //
 	define JoystickOverride		0						// Allows replacement of the Joystick Axis Preset Toggle to custom mappings. (NOTE: This will mean you will NOT be able to change your Joystick Axes Behaviour in-game & will remove any custom axis behaviour found in initSetJoystickCurves())		
 														//   Options:	Use Joystick Presets = 0 (default)			Use Custom Toggle Mappings = 1 


### PR DESCRIPTION
First, just want to say thanks for creating this script. It has greatly enhanced my enjoying of Elite Dangerous, especially when flying in VR!

I just recently came back to the game from a few months break, and previously (using version 4.1.0 of the script) I would bind the FSS absolute tuning to the left throttle axis since I would typically fly with forward only enabled, but didn't want to have to keep switching throttle presets when doing FSS scans. However, with version 4.2.1 the presets now apply to both throttle axes, which meant that I would have to switch presets when using the FSS.

This patch just makes syncing the two throttle axes optional by adding a new user preference to disable syncing (the option is enabled by default so as not to change the behavior of version 4.2.1 without intending to). I also refactored the throttle related code somewhat to (hopefully) make it easier to read/maintain.

Thanks again for all your hard work!